### PR TITLE
Add multiarch container builds

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64,darwin/arm64
+          platforms: linux/amd64,linux/arm64
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -79,7 +79,7 @@ jobs:
         - name: Build and push
           uses: docker/build-push-action@v5
           with:
-            platforms: linux/amd64,linux/arm64,darwin/arm64
+            platforms: linux/amd64,linux/arm64
             context: .
             file: Dockerfile.acme
             push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -31,6 +31,8 @@ jobs:
             type=sha    
       - name: setup Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Login to github container repo
         uses: docker/login-action@v3
         with:
@@ -40,6 +42,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64,darwin/arm64
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -76,6 +79,7 @@ jobs:
         - name: Build and push
           uses: docker/build-push-action@v5
           with:
+            platforms: linux/amd64,linux/arm64,darwin/arm64
             context: .
             file: Dockerfile.acme
             push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Was getting:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

when testing on Mac. This was solved in the dnsmasq-dhcp repo with https://github.com/OpenCHAMI/dnsmasq-dhcpd/pull/10, so this PR copies that config here to add mult-architecture container builds.